### PR TITLE
feat: netrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ EARTHDATA_USERNAME=your-user-name
 EARTHDATA_PASSWORD=your-password
 ```
 
+We also allow `.netrc` authentication, so set that up per [these instructions](https://nsidc.org/data/user-resources/help-center/creating-netrc-file-earthdata-login)
 Then:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An API client for [CSDA](https://csdap.earthdata.nasa.gov/).
 python -m pip install git+https://github.com/nasa-impact/csda-client
 ```
 
-We have [a notebook](./docs/search-and-download.ipynb) that demonstrates how to use the client:
+We have [a notebook](./docs/search-and-download.ipynb) that demonstrates how to use the client.
 
 ## Issues
 

--- a/docs/search-and-download.ipynb
+++ b/docs/search-and-download.ipynb
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "70ddd40c",
    "metadata": {},
    "outputs": [],
@@ -33,6 +33,7 @@
     "import rasterio.plot\n",
     "import tabulate\n",
     "from geopandas import GeoDataFrame\n",
+    "from httpx import BasicAuth\n",
     "from pystac_client import Client\n",
     "\n",
     "from csda_client import CsdaClient\n",
@@ -2833,7 +2834,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "9",
    "metadata": {},
    "outputs": [
@@ -2849,7 +2850,7 @@
     }
    ],
    "source": [
-    "client = CsdaClient.open(username=username, password=password)\n",
+    "client = CsdaClient.open(BasicAuth(username=username, password=password))\n",
     "client.verify()"
    ]
   },
@@ -2864,7 +2865,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "id": "11",
    "metadata": {},
    "outputs": [
@@ -2896,7 +2897,7 @@
     }
    ],
    "source": [
-    "profile = client.profile()\n",
+    "profile = client.profile(username)\n",
     "rows = []\n",
     "for vendor in profile.vendors:\n",
     "    rows.append([vendor.vendor, vendor.quota, vendor.quota_unit])\n",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 from typing import Any, Iterator
 
 import pytest
+from httpx import BasicAuth, NetRCAuth
 from pydantic import SecretStr
 from pytest import Config, Parser
 
@@ -25,12 +26,18 @@ def earthdata_password() -> SecretStr:
 
 
 @pytest.fixture(scope="session")
-def client(
+def basic_auth_client(
     earthdata_username: str, earthdata_password: SecretStr
 ) -> Iterator[CsdaClient]:
     with CsdaClient.open(
-        earthdata_username, earthdata_password.get_secret_value()
+        BasicAuth(earthdata_username, earthdata_password.get_secret_value())
     ) as client:
+        yield client
+
+
+@pytest.fixture(scope="session")
+def client() -> Iterator[CsdaClient]:
+    with CsdaClient.open(NetRCAuth()) as client:
         yield client
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -21,6 +21,6 @@ def test_download(client: CsdaClient, tmp_path: Path) -> None:
 
 
 @pytest.mark.with_earthdata_login
-def test_profile(client: CsdaClient, earthdata_username: str) -> None:
-    profile = client.profile()
+def test_profile(basic_auth_client: CsdaClient, earthdata_username: str) -> None:
+    profile = basic_auth_client.profile(earthdata_username)
     assert profile.earthdata_username == earthdata_username


### PR DESCRIPTION
Depends on https://github.com/NASA-IMPACT/csda-client/pull/43. Adds the ability to use netrc or basic auth for logging in.

Closes https://github.com/NASA-IMPACT/csda-client/issues/36

## To test

Set up your `~/.netrc` file like this, replacing `your-username` and `your-password`:

```netrc
machine urs.earthdata.nasa.gov
login your-username
password your-password
```

Then:

```shell
pytest --with-earthdata-login
```