### PR TITLE
fix: broken profile test

### DIFF
--- a/src/csda_client/models.py
+++ b/src/csda_client/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 from enum import Enum
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -13,7 +14,7 @@ class QuotaUnit(Enum):
 
 class Profile(BaseModel):
     earthdata_username: str
-    title: str
+    title: Optional[str] = None
     first_name: str
     last_name: str
     funding_agency: str

--- a/src/csda_client/models.py
+++ b/src/csda_client/models.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 from enum import Enum
-from typing import Optional
 
 from pydantic import BaseModel
 
@@ -14,7 +13,7 @@ class QuotaUnit(Enum):
 
 class Profile(BaseModel):
     earthdata_username: str
-    title: Optional[str] = None
+    title: str | None = None
     first_name: str
     last_name: str
     funding_agency: str

--- a/uv.lock
+++ b/uv.lock
@@ -564,7 +564,6 @@ name = "csda-client"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "contextily" },
     { name = "httpx" },
     { name = "pydantic" },
 ]
@@ -591,7 +590,6 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "contextily", specifier = ">=1.6.2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.11.7" },
 ]


### PR DESCRIPTION
My local test was throwing an error:
<img width="761" height="252" alt="Screenshot 2025-08-20 at 6 06 13 PM" src="https://github.com/user-attachments/assets/3c7938ed-c6f6-40c8-ad13-0d64edac1d14" />

related to a `null` title in [my profile](https://csdap-staging.ds.io/signup/api/users/emmalu/):
```json
{
"earthdata_username": "emmalu",
"title": null,
"first_name": "Emma",
"last_name": "Paz",
"email_address": "emma@developmentseed.org",
"funding_agency": "NASA",
...
}
```

Other fields default to an empty string, but not `title`: https://github.com/NASA-IMPACT/csdap_data_authorization/blob/3c4b7ac4712c8af82b6111197d3ed02ae073d44f/data_requests/models.py#L144


