### PR TITLE
feat: separate auth via Basic and Netrc

### DIFF
--- a/src/csda_client/models.py
+++ b/src/csda_client/models.py
@@ -13,7 +13,7 @@ class QuotaUnit(Enum):
 
 class Profile(BaseModel):
     earthdata_username: str
-    title: str
+    title: str | None
     first_name: str
     last_name: str
     funding_agency: str

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,18 +1,19 @@
 from pathlib import Path
 
 import pytest
+from conftest import get_username_from_netrc
 
 from csda_client.client import CsdaClient
 
 
 @pytest.mark.with_earthdata_login
-def test_open(client: CsdaClient) -> None:
-    client.verify()
+def test_open(netrc_client: CsdaClient) -> None:
+    netrc_client.verify()
 
 
 @pytest.mark.with_earthdata_login
-def test_download(client: CsdaClient, tmp_path: Path) -> None:
-    client.download(
+def test_download(netrc_client: CsdaClient, tmp_path: Path) -> None:
+    netrc_client.download(
         "planet",
         "PSScene-20160606_222940_0c74",
         "thumbnail",
@@ -21,6 +22,14 @@ def test_download(client: CsdaClient, tmp_path: Path) -> None:
 
 
 @pytest.mark.with_earthdata_login
-def test_profile(basic_auth_client: CsdaClient, earthdata_username: str) -> None:
+def test_profile_edl(basic_auth_client: CsdaClient, earthdata_username: str) -> None:
     profile = basic_auth_client.profile(earthdata_username)
     assert profile.earthdata_username == earthdata_username
+
+
+@pytest.mark.with_earthdata_login
+def test_profile_netrc(netrc_client: CsdaClient) -> None:
+    username = get_username_from_netrc()
+    assert username
+    profile = netrc_client.profile(str(username))
+    assert profile.earthdata_username == username

--- a/uv.lock
+++ b/uv.lock
@@ -564,7 +564,6 @@ name = "csda-client"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "contextily" },
     { name = "httpx" },
     { name = "pydantic" },
 ]
@@ -591,7 +590,6 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "contextily", specifier = ">=1.6.2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic", specifier = ">=2.11.7" },
 ]


### PR DESCRIPTION
Hey @gadomski, sorry to be obnoxious, but I couldn't let go of this note <sup>([ref](https://nsidc.org/data/user-resources/help-center/creating-netrc-file-earthdata-login))</sup>:

> When accessing NASA Earthdata resources, a .netrc file allows seamless authentication without being prompted for your Earthdata Login (EDL) username and password every time.

So I dug a little more into working with the `netrc` file and I think these changes should cover all scenarios, whether:
1. I'm a user with only a `.netrc` file
2. I'm a user with only a `.env` file
3. I'm a user with both

What do you think? Maybe I'm not understanding your train of thought either. But I wanted to convey my concerns over giving the option to login via `.netrc` but still requiring the `.env` file.